### PR TITLE
Call Cloudflare API successfully

### DIFF
--- a/server/handlers/photo.go
+++ b/server/handlers/photo.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"path"
 	"strconv"
@@ -67,14 +66,6 @@ func (h *handlers) GetPhotos() http.HandlerFunc {
 func (h *handlers) PostPhoto() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		r.ParseMultipartForm(32 << 20)
-		// get the preferred outgoing IP of this machine
-		conn, err := net.Dial("udp", "8.8.8.8:80")
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer conn.Close()
-		localAddr := conn.LocalAddr().(*net.UDPAddr)
-		log.Printf("Preferred Outbound IP: %+v", localAddr)
 		fileHeaders := r.MultipartForm.File["photo"]
 		for _, fileHeader := range fileHeaders {
 			file, err := fileHeader.Open()

--- a/server/handlers/photo.go
+++ b/server/handlers/photo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"path"
 	"strconv"
@@ -66,6 +67,14 @@ func (h *handlers) GetPhotos() http.HandlerFunc {
 func (h *handlers) PostPhoto() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		r.ParseMultipartForm(32 << 20)
+		// get the preferred outgoing IP of this machine
+		conn, err := net.Dial("udp", "8.8.8.8:80")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer conn.Close()
+		localAddr := conn.LocalAddr().(*net.UDPAddr)
+		log.Printf("Preferred Outbound IP: %+v", localAddr)
 		fileHeaders := r.MultipartForm.File["photo"]
 		for _, fileHeader := range fileHeaders {
 			file, err := fileHeader.Open()


### PR DESCRIPTION
Calls to the Cloudflare API were failing due to a TCP timeout. I believe the issue causing this was [Cloud Run using a dynamic IP pool to connect to external endpoints](https://cloud.google.com/run/docs/configuring/static-outbound-ip). 

I followed the linked guide and created a static IP for outbound requests. The `server` service is now also configured to redirect traffic directly to the default vpc. 